### PR TITLE
Elasticsearch 5.x.x binding: Avoiding IllegalArgumentException

### DIFF
--- a/bin/ycsb
+++ b/bin/ycsb
@@ -64,6 +64,7 @@ DATABASES = {
     "azuredocumentdb"   : "com.yahoo.ycsb.db.azuredocumentdb.AzureDocumentDBClient",
     "dynamodb"     : "com.yahoo.ycsb.db.DynamoDBClient",
     "elasticsearch": "com.yahoo.ycsb.db.ElasticsearchClient",
+    "elasticsearch5": "com.yahoo.ycsb.db.elasticsearch5.ElasticsearchClient",
     "geode"        : "com.yahoo.ycsb.db.GeodeClient",
     "googlebigtable"  : "com.yahoo.ycsb.db.GoogleBigtableClient",
     "googledatastore" : "com.yahoo.ycsb.db.GoogleDatastoreClient",

--- a/elasticsearch5/src/main/java/com/yahoo/ycsb/db/elasticsearch5/ElasticsearchClient.java
+++ b/elasticsearch5/src/main/java/com/yahoo/ycsb/db/elasticsearch5/ElasticsearchClient.java
@@ -86,16 +86,14 @@ public class ElasticsearchClient extends DB {
     int numberOfReplicas = parseIntegerProperty(props, "es.number_of_replicas", NUMBER_OF_REPLICAS);
 
     Boolean newdb = Boolean.parseBoolean(props.getProperty("es.newdb", "false"));
-    Builder settings = Settings.builder()
-        .put("cluster.name", DEFAULT_CLUSTER_NAME)
-        .put("path.home", pathHome);
+    Builder settings = Settings.builder();
 
     // if properties file contains elasticsearch user defined properties
     // add it to the settings file (will overwrite the defaults).
-    settings.put(props);
-    final String clusterName = settings.get("cluster.name");
+    
+    final String clusterName = props.getProperty("cluster.name", DEFAULT_CLUSTER_NAME);
     System.err.println("Elasticsearch starting node = " + clusterName);
-    System.err.println("Elasticsearch node path.home = " + settings.get("path.home"));
+    System.err.println("Elasticsearch node path.home = " + pathHome);
     System.err.println("Elasticsearch Remote Mode = " + remoteMode);
     // Remote mode support for connecting to remote elasticsearch cluster
     if(remoteMode) {
@@ -106,7 +104,8 @@ public class ElasticsearchClient extends DB {
       settings.put("client.transport.sniff", true)
           .put("client.transport.ignore_cluster_name", false)
           .put("client.transport.ping_timeout", "30s")
-          .put("client.transport.nodes_sampler_interval", "30s");
+          .put("client.transport.nodes_sampler_interval", "30s")
+          .put("cluster.name", clusterName);
       // Default it to localhost:9300
       String[] nodeList = props.getProperty("es.hosts.list", DEFAULT_REMOTE_HOST).split(",");
       System.out.println("Elasticsearch Remote Hosts = " + props.getProperty("es.hosts.list", DEFAULT_REMOTE_HOST));
@@ -126,6 +125,7 @@ public class ElasticsearchClient extends DB {
       }
       client = tClient;
     } else { // Start node only if transport client mode is disabled
+      settings.put(props);
       settings.put("transport.type", "local");
       settings.put("http.enabled", "false");
       node = new Node(settings.build());


### PR DESCRIPTION
Hello,

As mentioned [here](https://github.com/brianfrankcooper/YCSB/pull/925), the current implementation doesn't work with a remote ES instance (`es.remote=true`) and throws instead a `IllegalArgumentException`. Moreover, the parameter `path.home` has to be set despite not explicitly asked and needed.

I changed the way the variable `setting` is merged with `props` in `ElasticsearchClient.java` to make it work in remote mode and removed the need of setting `path.home`.

I tested the remote mode with `load` and `run` on a local cluster.

Best regards,

Phenyl